### PR TITLE
Remove UnauthenticatedBind from LdapAuth.Authenticate

### DIFF
--- a/src/ngx_auth/ldap_auth/bind_auth.go
+++ b/src/ngx_auth/ldap_auth/bind_auth.go
@@ -135,7 +135,6 @@ func (lba *LdapAuth) Authenticate(user, pass string) (bool, bool, error) {
 	if lba.conn.Bind(bind_dn, pass) != nil {
 		return false, false, nil
 	}
-	defer lba.conn.UnauthenticatedBind(bind_dn)
 
 	if lba.cfg.UniqueFilter != "" {
 		res, e := lba.conn.Search(lba.new_search_param(lba.cfg.UniqueFilter, user))


### PR DESCRIPTION
It seems there might be a misunderstanding regarding `ldap.Conn.UnauthenticatedBind`, which is intended for the unauthenticated authentication mechanism of the simple Bind method in LDAP.
See the following references for more details:
- https://pkg.go.dev/github.com/go-ldap/ldap/v3#Conn.UnauthenticatedBind
- https://datatracker.ietf.org/doc/html/rfc4513#section-5.1.2
- https://datatracker.ietf.org/doc/html/rfc4513#section-6.3.1

I believe what you intend is the anonymous authentication mechanism, which uses a zero-length username.
However, in the ngx_auth code, the `LdapAuth` connection is never used after returning from `LdapAuth.Authenticate`.
Therefore, invoking UnauthenticatedBind is both unnecessary and potentially harmful.

In fact, Active Directory Domain Controllers consider a simple Bind using the unauthenticated authentication mechanism, i.e. `ldap.Conn.UnauthenticatedBind`, as a logon failure with an incorrect password.
This can lead to account lockouts, depending on the account policies in place for Active Directory.